### PR TITLE
feat: Update markdown linter config

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,12 @@
+[global]
+exclude = [
+  ".git/**",
+]
+disable = [
+  "MD013",    # line-length - Line length
+  "MD032",    # Lists should be surrounded by blank
+]
+
+[MD007]
+indent = 2
+style  = "fixed"


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Add rumdl configuration for markdown linting

### Other Changes

<details>
<summary>chore(lint): add rumdl configuration (<a href="https://github.com/MasahiroSakoda/skills/commit/3464053d7e65083faf8bb314b50cfb3fcc6689bd">3464053</a>)</summary>

- Add .rumdl.toml for markdown linting rules
- Exclude .git directory from linting scans
- Disable rules for line length (MD013) and list spacing (MD032)
- Configure indentation (MD007) to use 2 spaces
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #5

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
