### PR TITLE
feat: Prepare skill publish

### DIFF
--- a/skills/chezmoi/SKILL.md
+++ b/skills/chezmoi/SKILL.md
@@ -6,13 +6,7 @@ description: >
     (Go template syntax, run_once_/run_onchange_ scripts, .chezmoidata),
     handling file attributes (symlinks, permissions, encryption, external sources),
     Troubleshooting chezmoi operations or understanding application order.
-allowed-tools:
-  - Read
-  - Edit
-  - Write
-  - Glob
-  - Grep
-  - Bash(chezmoi:*)
+allowed-tools: Read, Edit, Write, Glob, Grep, Bash(chezmoi:*)
 ---
 
 # chezmoi - Cross platform dotfiles manager

--- a/skills/chezmoi/SKILL.md
+++ b/skills/chezmoi/SKILL.md
@@ -6,6 +6,7 @@ description: >
     (Go template syntax, run_once_/run_onchange_ scripts, .chezmoidata),
     handling file attributes (symlinks, permissions, encryption, external sources),
     Troubleshooting chezmoi operations or understanding application order.
+license: MIT
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash(chezmoi:*)
 ---
 

--- a/skills/git-changelog/SKILL.md
+++ b/skills/git-changelog/SKILL.md
@@ -1,12 +1,7 @@
 ---
 name: git-changelog
 description: Generate changelog from current branch changes. Use when the user asks to write a changelog entry, fill the changelog section of a PR, or determine if changes are user-facing.
-allowed-tools:
-  - Bash(git log:*)
-  - Bash(git remote show origin)
-  - Bash(git branch --show-current)
-  - Bash(awk:*)
-  - Grep
+allowed-tools: Bash(git log:*), Bash(remote show origin), Bash(git branch --show-current), Bash(awk:*), Grep
 ---
 
 # Changelog Generator

--- a/skills/git-changelog/SKILL.md
+++ b/skills/git-changelog/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: git-changelog
 description: Generate changelog from current branch changes. Use when the user asks to write a changelog entry, fill the changelog section of a PR, or determine if changes are user-facing.
+license: MIT
 allowed-tools: Bash(git log:*), Bash(remote show origin), Bash(git branch --show-current), Bash(awk:*), Grep
 ---
 

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: git-commit
 description: Generate conventional commit message from staged changes. Use when asked to "commit", "stage and commit", "save changes", or after completing implementation tasks.
-allowed-tools:
-  - Bash(git diff:*)
+allowed-tools: Bash(git diff:*)
 ---
 
 # Conventional Commit Generator

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: git-commit
 description: Generate conventional commit message from staged changes. Use when asked to "commit", "stage and commit", "save changes", or after completing implementation tasks.
+license: MIT
 allowed-tools: Bash(git diff:*)
 ---
 


### PR DESCRIPTION
# Summary
<!-- add the description of the PR here -->

## Changelog

### What's Changed

- Standardize skill metadata by simplifying tool declarations and adding license information.

### Other Changes

<details>
<summary>docs(skills): add license information to skill metadata (<a href="https://github.com/MasahiroSakoda/skills/commit/df06c68">df06c68</a>)</summary>

- Add license: MIT to frontmatter of chezmoi, git-changelog, and git-commit skills
- Ensure all skills explicitly state their license for clarity and compliance
- Maintain consistency across the skill library metadata
</details>

<details>
<summary>chore(skills): simplify allowed-tools format in metadata (<a href="https://github.com/MasahiroSakoda/skills/commit/839fdae">839fdae</a>)</summary>

- Convert allowed-tools from multi-line list to comma-separated string
- Apply formatting update to chezmoi, git-changelog, and git-commit skills
- Clean up frontmatter metadata for improved consistency
</details>

## Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #9

## Notes
<!-- any additional notes for this PR -->

## Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

## How to test
<!-- if applicable, add testing instructions under this section -->
